### PR TITLE
Progress v1

### DIFF
--- a/src/app/App.scss
+++ b/src/app/App.scss
@@ -4,6 +4,7 @@
 @import "../shared_styles/general.scss";
 @import "../exercise/Exercise.scss";
 @import "../progress_bar_exercise/outline_button/OutlineButton.scss";
+@import "../progress_bar_exercise/progress_bar/ProgressBar.scss";
 
 .App {
   .exercise-index {

--- a/src/app/App.scss
+++ b/src/app/App.scss
@@ -3,6 +3,7 @@
 @import "../shared_styles/typography.scss";
 @import "../shared_styles/general.scss";
 @import "../exercise/Exercise.scss";
+@import "../progress_bar_exercise/outline_button/OutlineButton.scss";
 
 .App {
   .exercise-index {

--- a/src/progress_bar_exercise/ProgressBarExercise.js
+++ b/src/progress_bar_exercise/ProgressBarExercise.js
@@ -1,5 +1,6 @@
 import React from "react";
 import Exercise from "../exercise/Exercise";
+import OutlineButton from "./outline_button/OutlineButton";
 
 const ProgressBarExercise = () => {
   return (
@@ -18,5 +19,8 @@ export default ProgressBarExercise;
 // ----------------------------------------------------------------------------------
 
 const Solution = () => {
-  return <div>Add solution here</div>;
+  return <div>
+    <OutlineButton color='green'>Start Request</OutlineButton>
+    <OutlineButton color='red'>Finish Request</OutlineButton>
+  </div>;
 };

--- a/src/progress_bar_exercise/ProgressBarExercise.js
+++ b/src/progress_bar_exercise/ProgressBarExercise.js
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 import Exercise from "../exercise/Exercise";
+import AsyncProgressBar from "./async_progress_bar/AsyncProgressBar";
 import OutlineButton from "./outline_button/OutlineButton";
 
 const ProgressBarExercise = () => {
@@ -19,9 +20,24 @@ export default ProgressBarExercise;
 // ----------------------------------------------------------------------------------
 
 const Solution = () => {
-  return <div>
-    <ProgressBar progress={90}></ProgressBar>
-    <OutlineButton color='green' onClick={() => console.log('start clicked')}>Start Request</OutlineButton>
-    <OutlineButton color='red' onClick={() => console.log('finish clicked')}>Finish Request</OutlineButton>
+  const [requestState, setRequestState] = useState('inactive')
+
+  function startRequest() {
+    setRequestState('started')
+  }
+
+  function finishRequest() {
+    setRequestState('finished')
+  }
+
+  function deactivateRequest() {
+    setRequestState('inactive');
+  }
+return <div>
+    <AsyncProgressBar requestState={requestState} onFinished={deactivateRequest}></AsyncProgressBar>
+    <div className="buttons" style={{display: 'flex', width: '325px', height: '50px', alignItems: 'center', justifyContent: 'space-between'}}>
+      <OutlineButton color='green' onClick={startRequest} disabled={requestState === 'started'}>{requestState === 'started' ? 'Loading...' : 'Start Request' }</OutlineButton>
+      <OutlineButton color='red' onClick={finishRequest} disabled={requestState !== 'started'}>Finish Request</OutlineButton>
+    </div>
   </div>;
 };

--- a/src/progress_bar_exercise/ProgressBarExercise.js
+++ b/src/progress_bar_exercise/ProgressBarExercise.js
@@ -20,7 +20,8 @@ export default ProgressBarExercise;
 
 const Solution = () => {
   return <div>
-    <OutlineButton color='green'>Start Request</OutlineButton>
-    <OutlineButton color='red'>Finish Request</OutlineButton>
+    <ProgressBar progress={90}></ProgressBar>
+    <OutlineButton color='green' onClick={() => console.log('start clicked')}>Start Request</OutlineButton>
+    <OutlineButton color='red' onClick={() => console.log('finish clicked')}>Finish Request</OutlineButton>
   </div>;
 };

--- a/src/progress_bar_exercise/async_progress_bar/AsyncProgressBar.js
+++ b/src/progress_bar_exercise/async_progress_bar/AsyncProgressBar.js
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from "react";
+import { ProgressBar } from "../progress_bar/ProgressBar";
+
+export default function AsyncProgressBar({requestState = 'inactive', onFinished} = {}) {
+    if (!['inactive', 'started', 'finished'].includes(requestState)) {
+        console.error(`Invalid requestState ${requestState} passed`);
+    }
+    const [progress, setProgress] = useState(0);
+    const [fadeOut, setFadeOut] = useState(false);
+
+    useEffect(() => {
+        let progressInterval;
+        if (requestState === 'started') {
+            setFadeOut(false)
+            progressInterval = setInterval(() => {
+                if (progress <= 90) {
+                    setProgress(progress + 1)
+               }
+           }, 110)
+        } else if (requestState === 'finished') {
+            setProgress(100);
+            // let the progress bar finish animating to the end.
+            setTimeout(() => {
+                setFadeOut(true)
+            }, 1000)
+
+            // call onFinished and reset the progress to 0 after the bar fades out.
+            setTimeout(() => {
+                onFinished()
+                setProgress(0)
+            }, 5000) // 1s for finishing, 3s wait, 1s fadeout
+
+            clearInterval(progressInterval);
+        } 
+
+        return () => clearInterval(progressInterval)
+    }, [requestState, progress, onFinished])
+
+    return requestState !== 'inactive' ? <ProgressBar progress={progress} fadeOut={fadeOut}></ProgressBar> : null
+}

--- a/src/progress_bar_exercise/async_progress_bar/AsyncProgressBar.js
+++ b/src/progress_bar_exercise/async_progress_bar/AsyncProgressBar.js
@@ -28,7 +28,7 @@ export default function AsyncProgressBar({requestState = 'inactive', onFinished}
             setTimeout(() => {
                 onFinished()
                 setProgress(0)
-            }, 5000) // 1s for finishing, 3s wait, 1s fadeout
+            }, 4000) // 1s for finishing, 2s wait, 1s fadeout
 
             clearInterval(progressInterval);
         } 

--- a/src/progress_bar_exercise/outline_button/OutlineButton.js
+++ b/src/progress_bar_exercise/outline_button/OutlineButton.js
@@ -1,0 +1,10 @@
+import React from "react";
+// import './OutlineButton.scss';
+
+export default function OutlineButton({children, color}) { 
+    const child = typeof children === 'string' ? children.toUpperCase() : children;
+    const colorClass = color ? `outline_button--${color}` : '';
+
+
+    return <button className={`outline_button ${colorClass}`}>{child}</button>;
+}

--- a/src/progress_bar_exercise/outline_button/OutlineButton.js
+++ b/src/progress_bar_exercise/outline_button/OutlineButton.js
@@ -1,10 +1,10 @@
 import React from "react";
 // import './OutlineButton.scss';
 
-export default function OutlineButton({children, color}) { 
+export default function OutlineButton({children, color, ...props}) { 
     const child = typeof children === 'string' ? children.toUpperCase() : children;
     const colorClass = color ? `outline_button--${color}` : '';
 
 
-    return <button className={`outline_button ${colorClass}`}>{child}</button>;
+    return <button className={`outline_button ${colorClass}`} {...props}>{child}</button>;
 }

--- a/src/progress_bar_exercise/outline_button/OutlineButton.scss
+++ b/src/progress_bar_exercise/outline_button/OutlineButton.scss
@@ -8,11 +8,15 @@
     font-size: 12px;
     letter-spacing: 1px;
 
-    &:hover {
+    &:disabled {
+        opacity: 50%;
+    }
+
+    &:hover:not([disabled]) {
         border-width: 2px;
     }
 
-    &:active {
+    &:active:not([disabled]) {
         border-width: 3px;
     }
 

--- a/src/progress_bar_exercise/outline_button/OutlineButton.scss
+++ b/src/progress_bar_exercise/outline_button/OutlineButton.scss
@@ -1,0 +1,28 @@
+// @use '../../shared_styles/colors.scss';
+
+.outline_button{
+    border: 1px solid black;
+    border-radius: 20px;
+    padding: 0.75rem 1rem;
+    font-weight: 600;
+    font-size: 12px;
+    letter-spacing: 1px;
+
+    &:hover {
+        border-width: 2px;
+    }
+
+    &:active {
+        border-width: 3px;
+    }
+
+    &--green {
+        border-color: $green;
+        color: $green;
+    }
+
+    &--red {
+        border-color: $red;
+        color: $red;
+    }
+}

--- a/src/progress_bar_exercise/progress_bar/ProgressBar.js
+++ b/src/progress_bar_exercise/progress_bar/ProgressBar.js
@@ -1,0 +1,14 @@
+import React from "react"
+
+export function ProgressBar({progress}) {
+    const percent = progress > 100 ? 100 
+                    : progress < 0 ? 0 
+                    : progress;
+    // get viewport width
+    const vw = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+    // calculate the amount that needs to be hidden
+    const percentHidden = 100 - percent;
+    const hiddenAmount = percentHidden * vw / 100
+
+    return <div className="progress-bar" style={{clipPath: `inset(0px ${hiddenAmount}px 0px 0px)`}}></div>
+}

--- a/src/progress_bar_exercise/progress_bar/ProgressBar.js
+++ b/src/progress_bar_exercise/progress_bar/ProgressBar.js
@@ -1,6 +1,6 @@
 import React from "react"
 
-export function ProgressBar({progress}) {
+export function ProgressBar({progress, fadeOut}) {
     const percent = progress > 100 ? 100 
                     : progress < 0 ? 0 
                     : progress;
@@ -10,5 +10,5 @@ export function ProgressBar({progress}) {
     const percentHidden = 100 - percent;
     const hiddenAmount = percentHidden * vw / 100
 
-    return <div className="progress-bar" style={{clipPath: `inset(0px ${hiddenAmount}px 0px 0px)`}}></div>
+    return <div className={`progress-bar ${fadeOut ? 'progress-bar--fade-out' : ''}`} style={{clipPath: `inset(0px ${hiddenAmount}px 0px 0px)`}}></div>
 }

--- a/src/progress_bar_exercise/progress_bar/ProgressBar.scss
+++ b/src/progress_bar_exercise/progress_bar/ProgressBar.scss
@@ -9,6 +9,6 @@
 
     &--fade-out {
         opacity: 0%;
-        transition: opacity 1s 3s;
+        transition: opacity 1s 2s;
     }
 }

--- a/src/progress_bar_exercise/progress_bar/ProgressBar.scss
+++ b/src/progress_bar_exercise/progress_bar/ProgressBar.scss
@@ -1,0 +1,8 @@
+.progress-bar {
+    position: fixed;
+    top: 0px;
+    left: 0px;
+    width: 100vw;
+    height: 6px;
+    background: linear-gradient(to right, $sunrise, $red);
+}

--- a/src/progress_bar_exercise/progress_bar/ProgressBar.scss
+++ b/src/progress_bar_exercise/progress_bar/ProgressBar.scss
@@ -5,4 +5,10 @@
     width: 100vw;
     height: 6px;
     background: linear-gradient(to right, $sunrise, $red);
+    transition: clip-path 1s linear;
+
+    &--fade-out {
+        opacity: 0%;
+        transition: opacity 1s 3s;
+    }
 }


### PR DESCRIPTION
Create an asynchronous progress bar at the top of the page, triggered by buttons.

I first created a generic `ProgressBar` component that I could then utilize inside of the `AsyncProgressBar`, allowing for more general usage.

The `ProgressBar` stays the full width, and used a `clip-path` to cover the inverse percentage. This may be slightly more complicated than just adjusting the width (or having another element cover/uncover the visible element), but it allows for a single element and makes it easy to put on a variety of backgrounds.

I do feel the logic in the `AsyncProgressBar` component is clunky, having multiple `setTimeouts` to get the fades and animations correct, I figured it was good enough to work for now, and it's self contained enough that there shouldn't be an issue adjusting it if used elsewhere.

It took me about 3 hours to get this done.